### PR TITLE
feat: add setting allowing for custom nasm path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ This extension contributes the following settings:
 - `nasm.outputFormat`: Changes the executable output format to assemble for. This is neccesary to provide correct errors based on your build target.
 - `nasm.reportWarnings`: If disabled, warnings will be supressed.
 - `nasm.extraFlags`: Extra flags (for example, `-w+all`) that will be appended when running `nasm` when validating assembly files
+- `nasm.nasmPath`: The name or path of the nasm executable (e.g. `/opt/homebrew/bin/nasm`, `/usr/local/bin/nasm`)

--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
                     "default": true,
                     "description": "If disabled, validation warnings will be ignored"
                 },
+                "nasm.nasmPath": {
+                    "title": "NASM Path",
+                    "type": "string",
+                    "default": "nasm",
+                    "description": "The name or path of the nasm executable (e.g. `/opt/homebrew/bin/nasm`, `/usr/local/bin/nasm`)"
+                },
                 "nasm.extraFlags": {
                     "type": "array",
                     "default": [],


### PR DESCRIPTION
This allows users to provide a `nasm` executable that is not in their `PATH` environment variable.