### PR TITLE
feat: add option to check source code as the user types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "nasm-language-support" extension will be documented 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 1.1.2
+
+- Added the `nasm.nasmPath` setting which allows you to use a custom `nasm` binary rather than one in your `PATH` environment variable
+- Added the `nasm.checkOnType` setting which checks your code as you type rather than after you save.
+
 ## 1.1.1
 
 - Fixed a bug that caused the extension not to work on Windows

--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ This extension contributes the following settings:
 - `nasm.reportWarnings`: If disabled, warnings will be supressed.
 - `nasm.extraFlags`: Extra flags (for example, `-w+all`) that will be appended when running `nasm` when validating assembly files
 - `nasm.nasmPath`: The name or path of the nasm executable (e.g. `/opt/homebrew/bin/nasm`, `/usr/local/bin/nasm`)
+- `nasm.checkOnType`: If enabled, validates assembly files as you type rather than after saving.bb

--- a/package.json
+++ b/package.json
@@ -98,12 +98,12 @@
                         "type": "string"
                     },
                     "description": "Extra flags to add to `nasm` when validating source code"
+                },
+                "nasm.checkOnType": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If enabled, validates assembly files as you type instead of after you save the file."
                 }
-            },
-            "nasm.checkOnType": {
-                "type": "boolean",
-                "default": false,
-                "description": "If enabled, validates assembly files as you type instead of after you save the file."
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nasm-language-support",
     "displayName": "NASM Language Support",
     "description": "Language features for NASM Assembly",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "engines": {
         "vscode": "^1.67.0"
     },

--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
                     },
                     "description": "Extra flags to add to `nasm` when validating source code"
                 }
+            },
+            "nasm.checkOnType": {
+                "type": "boolean",
+                "default": false,
+                "description": "If enabled, validates assembly files as you type instead of after you save the file."
             }
         }
     },


### PR DESCRIPTION
This pull request adds a "check on type" option that enables checking assembly files as you type instead of after you save the file. Resolves #3.